### PR TITLE
Change CryptoService Iteration and salt size to reduce cpu computing …

### DIFF
--- a/DSLNG.PEAR/DSLNG.PEAR.Services/UserService.cs
+++ b/DSLNG.PEAR/DSLNG.PEAR.Services/UserService.cs
@@ -20,10 +20,12 @@ namespace DSLNG.PEAR.Services
     {
         //private PasswordHasher _pass = new PasswordHasher();
         private PBKDF2 crypto = new PBKDF2();
+        
 
         public UserService(IDataContext dataContext)
             : base(dataContext)
         {
+            
         }
 
         public GetUsersResponse GetUsers(GetUsersRequest request)
@@ -66,6 +68,8 @@ namespace DSLNG.PEAR.Services
             var response = new CreateUserResponse();
             try
             {
+                crypto.HashIterations = 10;
+                crypto.SaltSize = 12;
 
                 var user = request.MapTo<User>();
                 user.Role = DataContext.RoleGroups.First(x => x.Id == request.RoleId);
@@ -87,6 +91,8 @@ namespace DSLNG.PEAR.Services
 
         public UpdateUserResponse Update(UpdateUserRequest request)
         {
+            crypto.HashIterations = 10;
+            crypto.SaltSize = 12;
             var response = new UpdateUserResponse();
             try
             {
@@ -100,7 +106,7 @@ namespace DSLNG.PEAR.Services
                 user.ChangeModel = request.ChangeModel;
                 if (request.ChangePassword && request.Password != null)
                 {
-                    user.PasswordSalt = crypto.Salt != null ? crypto.Salt : crypto.GenerateSalt(crypto.HashIterations, crypto.SaltSize);
+                    user.PasswordSalt = crypto.GenerateSalt(crypto.HashIterations, crypto.SaltSize);
                     user.Password = crypto.Compute(request.Password, user.PasswordSalt);
                 }
                 DataContext.Users.Attach(user);
@@ -147,8 +153,20 @@ namespace DSLNG.PEAR.Services
                 var user = DataContext.Users.Where(x => x.Email == request.Email).Include(x => x.Role).Include(y => y.RolePrivileges).First();
                 if (user != null && user.Password == crypto.Compute(request.Password, user.PasswordSalt))
                 {
+                    //Add For Update Password
+                    int HashIteration = int.Parse(user.PasswordSalt.Substring(0, user.PasswordSalt.IndexOf('.')),System.Globalization.NumberStyles.Number);
+                    if (HashIteration > 10)
+                    {
+                        ChangePassword(new ChangePasswordRequest
+                        {
+                            Id = user.Id,
+                            Old_Password = request.Password,
+                            New_Password = request.Password
+                        });
+                    }
                     //Include(x => x.Role).
                     response = user.MapTo<LoginUserResponse>();
+                    response.Message = "Your Password is :" + crypto.Compute(request.Password, user.PasswordSalt);
                     response.IsSuccess = true;
                 }
                 else
@@ -200,14 +218,19 @@ namespace DSLNG.PEAR.Services
             var user = DataContext.Users.First(x => x.Id == request.Id).MapTo<User>();
             if (user != null)
             {
-
+                
                 if (user.Password != crypto.Compute(request.Old_Password, user.PasswordSalt))
                 {
                     response.Message = "Current Password isn't correct!";
                     return response;
                 }
 
-                user.PasswordSalt = crypto.Salt != null ? crypto.Salt : crypto.GenerateSalt(crypto.HashIterations, crypto.SaltSize);
+                // change to lesser crypto
+                crypto.HashIterations = 10;
+                crypto.SaltSize = 12;
+
+                //user.PasswordSalt = crypto.Salt != null ? crypto.Salt : crypto.GenerateSalt(crypto.HashIterations, crypto.SaltSize);
+                user.PasswordSalt = crypto.GenerateSalt(crypto.HashIterations, crypto.SaltSize);
                 user.Password = crypto.Compute(request.New_Password, user.PasswordSalt);
 
                 DataContext.Users.Attach(user);


### PR DESCRIPTION
…time consume.

The change:
Login Method: will update old hash password and salt with new updated hashiteration automatically depends on password salt content, the first order of password salt are hashiteration, so, basically change that has iteration on database from 100000 iteration to just only 10 and reduce saltsize from 34byte to only 12byte
login method will call change password service when condition are applied
Update Method: using new logic of hash encryption

Basically no change needed on user data, and implementation will seamlessly added to current application without user notice but speed increasing while logged-in.